### PR TITLE
fix(manisfest): correct name in package.json/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# companion-module-tesmart-hdmi-matrix
+# companion-module-tesmart-hdmimatrix"
 
 See HELP.md and License.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "tesmart-hdmi-matrix",
+	"name": "tesmart-hdmimatrix",
 	"version": "1.0.0",
 	"api_version": "1.0.0",
 	"keywords": [


### PR DESCRIPTION
Updated name from `tesmart-hdmi-matrix` to `tesmart-hdmimatrix`

Resolves bitfocus#2

Signed-off-by: Johnny Estilles <johnny@estilles.com>